### PR TITLE
天下官網 - 解決 sky 蓋到會員選單的問題

### DIFF
--- a/assets/sass/sky.scss
+++ b/assets/sass/sky.scss
@@ -14,7 +14,8 @@
   height: 5rem;
   z-index: 14;
 
-  &.standby {
+  &.standby,
+  &.notification {
     z-index: 11;
   }
 
@@ -683,6 +684,7 @@
     }
 
     &.opened-half {
+      z-index: 10;
       background: linear-gradient(180deg, rgba($black, 0) 70%, rgba($black, 0.7) 100%);
     }
   }


### PR DESCRIPTION
先將半屏 mask z-index 往後調整，繞過目前遇到的情境